### PR TITLE
C++20 fixes

### DIFF
--- a/include/zep/mcommon/signals.h
+++ b/include/zep/mcommon/signals.h
@@ -293,7 +293,11 @@ class signal_accumulator
 {
 public:
     /// Result type when calling the accumulating function operator.
+    #if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
+    using result_type = typename std::invoke_result<F, T, typename S::slot_type::result_type>::type;
+    #else
     using result_type = typename std::result_of<F(T, typename S::slot_type::result_type)>::type;
+    #endif
 
     /// Construct a signal_accumulator as a proxy to a given signal
     //

--- a/include/zep/mcommon/string/stringutils.h
+++ b/include/zep/mcommon/string/stringutils.h
@@ -94,7 +94,7 @@ struct StringId
     StringId()
     {
     }
-    StringId(const char* pszString);
+    explicit StringId(const char* pszString);
     StringId(const std::string& str);
     explicit StringId(uint32_t _id)
     {


### PR DESCRIPTION
- The explicit conversion from a const char* for StringId removes the ambiguity of the operator== that gets introduced in C++20
- std::result_of has been removed in C++20, and its replacement, std::invoke_result, that got introduced in C++17, has a slightly different instantiation mechanism

Addresses #72, at least partially.

I am not necessarily happy with the way `#ifdef` is used there, but I don't think I could get `std::conditional` to work properly for this, and I didn't see any other way out. MSVC doesn't define `__cplusplus` properly by default, so `_MSVC_LANG` is used in this case.

Things not addressed: this still makes use of C++ deprecated features, such as the std::iterator template, which may break later on.

I couldn't necessarily test this in many settings. This could be considered a draft / proposal to make Zep be C++20-friendly.