### PR TITLE
Use ImGui's Alpha style variable to modulate Zep-drawn elements

### DIFF
--- a/include/zep/imgui/display_imgui.h
+++ b/include/zep/imgui/display_imgui.h
@@ -79,7 +79,7 @@ public:
         {
             text_end = text_begin + strlen((const char*)text_begin);
         }
-        auto const modulatedColor = ToPackedABGR(NVec4f(col.x, col.y, col.z, col.w * ImGui::GetStyle().Alpha));
+        const auto modulatedColor = GetStyleModulatedColor(col);
         if (m_clipRect.Width() == 0)
         {
             drawList->AddText(imFont, float(font.GetPixelHeight()), toImVec2(pos), modulatedColor, (const char*)text_begin, (const char*)text_end);
@@ -95,7 +95,7 @@ public:
     void DrawLine(const NVec2f& start, const NVec2f& end, const NVec4f& color, float width) const override
     {
         ImDrawList* drawList = ImGui::GetWindowDrawList();
-        auto const modulatedColor = ToPackedABGR(NVec4f(color.x, color.y, color.z, color.w * ImGui::GetStyle().Alpha));
+        const auto modulatedColor = GetStyleModulatedColor(color);
         // Background rect for numbers
         if (m_clipRect.Width() == 0)
         {
@@ -112,7 +112,7 @@ public:
     void DrawRectFilled(const NRectf& rc, const NVec4f& color) const override
     {
         ImDrawList* drawList = ImGui::GetWindowDrawList();
-        auto const modulatedColor = ToPackedABGR(NVec4f(color.x, color.y, color.z, color.w * ImGui::GetStyle().Alpha));
+        const auto modulatedColor = GetStyleModulatedColor(color);
         // Background rect for numbers
         if (m_clipRect.Width() == 0)
         {
@@ -142,6 +142,11 @@ public:
 
 
 private:
+    static ImU32 GetStyleModulatedColor(const NVec4f& color)
+    {
+        return ToPackedABGR(NVec4f(color.x, color.y, color.z, color.w * ImGui::GetStyle().Alpha));
+    }
+
     NRectf m_clipRect;
 }; // namespace Zep
 

--- a/include/zep/imgui/display_imgui.h
+++ b/include/zep/imgui/display_imgui.h
@@ -79,14 +79,15 @@ public:
         {
             text_end = text_begin + strlen((const char*)text_begin);
         }
+        auto const modulatedColor = ToPackedABGR(NVec4f(col.x, col.y, col.z, col.w * ImGui::GetStyle().Alpha));
         if (m_clipRect.Width() == 0)
         {
-            drawList->AddText(imFont, float(font.GetPixelHeight()), toImVec2(pos), ToPackedABGR(col), (const char*)text_begin, (const char*)text_end);
+            drawList->AddText(imFont, float(font.GetPixelHeight()), toImVec2(pos), modulatedColor, (const char*)text_begin, (const char*)text_end);
         }
         else
         {
             drawList->PushClipRect(toImVec2(m_clipRect.topLeftPx), toImVec2(m_clipRect.bottomRightPx));
-            drawList->AddText(imFont, float(font.GetPixelHeight()), toImVec2(pos), ToPackedABGR(col), (const char*)text_begin, (const char*)text_end);
+            drawList->AddText(imFont, float(font.GetPixelHeight()), toImVec2(pos), modulatedColor, (const char*)text_begin, (const char*)text_end);
             drawList->PopClipRect();
         }
     }
@@ -94,15 +95,16 @@ public:
     void DrawLine(const NVec2f& start, const NVec2f& end, const NVec4f& color, float width) const override
     {
         ImDrawList* drawList = ImGui::GetWindowDrawList();
+        auto const modulatedColor = ToPackedABGR(NVec4f(color.x, color.y, color.z, color.w * ImGui::GetStyle().Alpha));
         // Background rect for numbers
         if (m_clipRect.Width() == 0)
         {
-            drawList->AddLine(toImVec2(start), toImVec2(end), ToPackedABGR(color), width);
+            drawList->AddLine(toImVec2(start), toImVec2(end), modulatedColor, width);
         }
         else
         {
             drawList->PushClipRect(toImVec2(m_clipRect.topLeftPx), toImVec2(m_clipRect.bottomRightPx));
-            drawList->AddLine(toImVec2(start), toImVec2(end), ToPackedABGR(color), width);
+            drawList->AddLine(toImVec2(start), toImVec2(end), modulatedColor, width);
             drawList->PopClipRect();
         }
     }
@@ -110,15 +112,16 @@ public:
     void DrawRectFilled(const NRectf& rc, const NVec4f& color) const override
     {
         ImDrawList* drawList = ImGui::GetWindowDrawList();
+        auto const modulatedColor = ToPackedABGR(NVec4f(color.x, color.y, color.z, color.w * ImGui::GetStyle().Alpha));
         // Background rect for numbers
         if (m_clipRect.Width() == 0)
         {
-            drawList->AddRectFilled(toImVec2(rc.topLeftPx), toImVec2(rc.bottomRightPx), ToPackedABGR(color));
+            drawList->AddRectFilled(toImVec2(rc.topLeftPx), toImVec2(rc.bottomRightPx), modulatedColor);
         }
         else
         {
             drawList->PushClipRect(toImVec2(m_clipRect.topLeftPx), toImVec2(m_clipRect.bottomRightPx));
-            drawList->AddRectFilled(toImVec2(rc.topLeftPx), toImVec2(rc.bottomRightPx), ToPackedABGR(color));
+            drawList->AddRectFilled(toImVec2(rc.topLeftPx), toImVec2(rc.bottomRightPx), modulatedColor);
             drawList->PopClipRect();
         }
     }


### PR DESCRIPTION
- ref: https://github.com/Rezonality/zep/discussions/77

# Description

When using Zep within ImGui, the editor was not respecting ImGui's `Alpha` style variable, which is supposed to affect all subsequent elements.

This is a *proposal* to fix #77

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- I was unable to build the Zep project on Linux because it was unable to find the toolchain file `vcpkg.make` (I've been working with just the C++ files for Zep inside my own project, not building all of Zep with its dependencies)
