### PR TITLE
Support <Home> and <End> key commands in Standard and Vim modes

### DIFF
--- a/include/zep/keymap.h
+++ b/include/zep/keymap.h
@@ -104,8 +104,10 @@ DECLARE_COMMANDID(MotionNextSearch)
 DECLARE_COMMANDID(MotionPreviousSearch)
 
 DECLARE_COMMANDID(MotionLineEnd)
+DECLARE_COMMANDID(MotionLineBeyondEnd)
 DECLARE_COMMANDID(MotionLineBegin)
 DECLARE_COMMANDID(MotionLineFirstChar)
+DECLARE_COMMANDID(MotionLineHomeToggle)
 
 DECLARE_COMMANDID(MotionRightSplit)
 DECLARE_COMMANDID(MotionLeftSplit)

--- a/src/mode.cpp
+++ b/src/mode.cpp
@@ -2486,8 +2486,7 @@ void ZepMode::AddNavigationKeyMaps(bool allowInVisualMode)
     // Line Motions
     AddKeyMapWithCountRegisters(navigationMaps, { "$", "<End>" }, id_MotionLineEnd);
     AddKeyMapWithCountRegisters(navigationMaps, { "^" }, id_MotionLineFirstChar);
-    keymap_add(navigationMaps, { "0" }, id_MotionLineBegin);
-    keymap_add(navigationMaps, { "<Home>" }, id_MotionLineHomeToggle);
+    keymap_add(navigationMaps, { "0", "<Home>" }, id_MotionLineBegin);
 
     // Word motions
     AddKeyMapWithCountRegisters(navigationMaps, { "w" }, id_MotionWord);
@@ -2513,7 +2512,7 @@ void ZepMode::AddNavigationKeyMaps(bool allowInVisualMode)
     keymap_add({ &m_insertMap }, { "<Left>" }, id_MotionLeft);
 
     keymap_add({ &m_insertMap }, { "<End>" }, id_MotionLineBeyondEnd);
-    keymap_add({ &m_insertMap }, { "<Home>" }, id_MotionLineHomeToggle);
+    keymap_add({ &m_insertMap }, { "<Home>" }, id_MotionLineBegin);
 }
 
 void ZepMode::AddSearchKeyMaps()

--- a/src/mode.cpp
+++ b/src/mode.cpp
@@ -907,6 +907,11 @@ bool ZepMode::GetCommand(CommandContext& context)
         GetCurrentWindow()->SetBufferCursor(context.buffer.GetLinePos(bufferCursor, LineLocation::LineLastNonCR));
         return true;
     }
+    else if (mappedCommand == id_MotionLineBeyondEnd)
+    {
+        GetCurrentWindow()->SetBufferCursor(context.buffer.GetLinePos(bufferCursor, LineLocation::LineCRBegin));
+        return true;
+    }
     else if (mappedCommand == id_MotionLineBegin)
     {
         GetCurrentWindow()->SetBufferCursor(context.buffer.GetLinePos(bufferCursor, LineLocation::LineBegin));
@@ -915,6 +920,16 @@ bool ZepMode::GetCommand(CommandContext& context)
     else if (mappedCommand == id_MotionLineFirstChar)
     {
         GetCurrentWindow()->SetBufferCursor(context.buffer.GetLinePos(bufferCursor, LineLocation::LineFirstGraphChar));
+        return true;
+    }
+    else if (mappedCommand == id_MotionLineHomeToggle)
+    {
+        auto newCursorPos = context.buffer.GetLinePos(bufferCursor, LineLocation::LineFirstGraphChar);
+        if (bufferCursor == newCursorPos)
+        {
+            newCursorPos = context.buffer.GetLinePos(bufferCursor, LineLocation::LineBegin);
+        }
+        GetCurrentWindow()->SetBufferCursor(newCursorPos);
         return true;
     }
     // Moving between tabs
@@ -2469,9 +2484,10 @@ void ZepMode::AddNavigationKeyMaps(bool allowInVisualMode)
     AddKeyMapWithCountRegisters(navigationMaps, { "G" }, id_MotionGotoLine);
 
     // Line Motions
-    AddKeyMapWithCountRegisters(navigationMaps, { "$" }, id_MotionLineEnd);
+    AddKeyMapWithCountRegisters(navigationMaps, { "$", "<End>" }, id_MotionLineEnd);
     AddKeyMapWithCountRegisters(navigationMaps, { "^" }, id_MotionLineFirstChar);
     keymap_add(navigationMaps, { "0" }, id_MotionLineBegin);
+    keymap_add(navigationMaps, { "<Home>" }, id_MotionLineHomeToggle);
 
     // Word motions
     AddKeyMapWithCountRegisters(navigationMaps, { "w" }, id_MotionWord);
@@ -2495,6 +2511,9 @@ void ZepMode::AddNavigationKeyMaps(bool allowInVisualMode)
     keymap_add({ &m_insertMap }, { "<Up>" }, id_MotionUp);
     keymap_add({ &m_insertMap }, { "<Right>" }, id_MotionRight);
     keymap_add({ &m_insertMap }, { "<Left>" }, id_MotionLeft);
+
+    keymap_add({ &m_insertMap }, { "<End>" }, id_MotionLineBeyondEnd);
+    keymap_add({ &m_insertMap }, { "<Home>" }, id_MotionLineHomeToggle);
 }
 
 void ZepMode::AddSearchKeyMaps()

--- a/src/mode_standard.cpp
+++ b/src/mode_standard.cpp
@@ -58,6 +58,9 @@ void ZepMode_Standard::Init()
     keymap_add({ &m_insertMap, &m_visualMap }, { "<Up>" }, id_MotionStandardUp);
     keymap_add({ &m_insertMap, &m_visualMap }, { "<Down>" }, id_MotionStandardDown);
    
+    keymap_add({ &m_insertMap }, { "<End>" }, id_MotionLineBeyondEnd);
+    keymap_add({ &m_insertMap }, { "<Home>" }, id_MotionLineHomeToggle);
+
     keymap_add({ &m_insertMap }, { "<C-Left>" }, id_MotionStandardLeftWord);
     keymap_add({ &m_insertMap }, { "<C-Right>" }, id_MotionStandardRightWord);
     


### PR DESCRIPTION
# Description

The **End** key moves to the end of line (at or "beyond", depending on insert mode).

The **Home** key moves to the first "graph" (non-whitespace) character if it's not already there, otherwise it toggles to the start of the line, similar to what most editors do (e.g. VS, Notepad++).

Partially addresses #40

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update (I don't see any documentation that refers to keys like this, let me know if there's something I should add!)

**Test Configuration**:
* OS: Windows 11

# Checklist:

- [x] My code has been formatted with the clang format file
