### PR TITLE
Adding missing cstdint include in stringutils

### DIFF
--- a/include/zep/mcommon/string/stringutils.h
+++ b/include/zep/mcommon/string/stringutils.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <cstdint>
 
 namespace Zep
 {


### PR DESCRIPTION
# Description

This was failing to build on my machine, since I guess one of the std headers did not include <cstdint> as expected.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* OS: Arch Linux

# Checklist:

- [X] My code has been formatted with the clang format file

